### PR TITLE
fix: 장바구니 페이지, 주문 명, 주문 상태 API 수정

### DIFF
--- a/public/sitemap.json
+++ b/public/sitemap.json
@@ -1,1 +1,1 @@
-["","/cart","/eventinfo","/inquiry","/payment","/mypage","/products","/social_login","/payment/callback","/payment/success","/mypage/myreviews","/mypage/editinfo","/mypage/withdrwal","/mypage/orderhistory","/products/[id]","/social_login/callback","/mypage/orderhistory/writereview"]
+["","/cart","/eventinfo","/products","/mypage","/payment","/inquiry","/social_login","/products/[id]","/mypage/myreviews","/mypage/editinfo","/mypage/orderhistory","/mypage/withdrwal","/payment/callback","/payment/success","/social_login/callback","/mypage/orderhistory/writereview"]

--- a/src/apis/order/OrderApi.ts
+++ b/src/apis/order/OrderApi.ts
@@ -20,6 +20,8 @@ import {
   OrderPutByIdParamType,
   OrderPutByIdReturnType,
   OrderStatusGetByIdParamType,
+  OrderStatusIdGetParamType,
+  OrderStatusIdGetReturnType,
   OrderStatusType,
 } from './OrderApi.type';
 import { UserDTOType } from '@apis/user/UserApi.type';
@@ -113,31 +115,16 @@ export class OrderApi {
     })
     return { orderResults:orderDataList, ...orderStatusData};
   };
-  getOrderStatusById = async (params: OrderStatusGetByIdParamType): Promise<OrderStatusType | undefined> => {
-    const userData = await this.axios.get<UserDTOType>(`/v1/user/me/`)
+  getOrderStatusById = async (params: OrderStatusGetByIdParamType): Promise<OrderStatusType[]> => {
     const { orderId } = params
     let page = 1
-    const orderStatusParam = {
-      user_id: userData.data.id,
+    const orderStatusIdParam = {
+      order_id: orderId,
       page,
     }
-    const { data } = await this.axios.get<OrderGetStatusReturnType>(`/v1/order/status/`, { data: orderStatusParam })
-    const filterList = data.results.filter((orderStatusData) => orderStatusData.orderId === orderId)
-    if (filterList.length !== 0) return filterList[0]
-    let nextPage = data.next
-    while (page < 5) {
-      page++
-      const { data } = await this.axios.get<OrderGetStatusReturnType>(`/v1/order/status/`, { data: orderStatusParam })
-      console.log(`# page ${page}의 orderStatus:`, data)
-      nextPage = data.next
-      const filterList = data.results.filter((orderStatusData) => orderStatusData.orderId === orderId)
-      if (filterList.length !== 0) {
-        console.log("# OrderId에 해당하는 주문의 OrderStatus:", filterList)
-        return filterList[0]
-      }
-    }
-    console.log("# OrderId에 해당하는 주문의 OrderStatus가 없습니다.")
-    return undefined
+    const { data } = await this.axios.get<OrderStatusIdGetReturnType>(`/v1/order/status/id/`, {data: orderStatusIdParam})
+    if(data.results.length === 0) return []
+    return data.results
   };
   postOrderStatus = async (params: OrderPostStatusParamType): Promise<OrderPostStatusReturnType> => {
     const { data } = await this.axios({

--- a/src/apis/order/OrderApi.type.ts
+++ b/src/apis/order/OrderApi.type.ts
@@ -127,6 +127,18 @@ export type OrderStatusType = {
   count: number,
   created: string,
 }
+// GET /v1/order/status/id/ order id로 주문 내역 받아오기
+export type OrderStatusIdGetParamType = {
+  page?: number,
+  page_size?: number,
+  order_id: string,
+}
+export type OrderStatusIdGetReturnType = {
+  count: number,
+  next?: string,
+  previous?: string,
+  results: OrderStatusType[]
+}
 // POST /v1/order/status/
 export type OrderPostStatusParamType = {
   orderId: string,

--- a/src/components/PaymentSuccessPage/PaymentSuccessPage.tsx
+++ b/src/components/PaymentSuccessPage/PaymentSuccessPage.tsx
@@ -19,26 +19,25 @@ interface PaymentSuccessPageDataProps extends ChakraProps {
 interface PaymentSuccessPageProps extends Omit<PaymentSuccessPageDataProps,"resOrderId"> {
   orderData: OrderGetByIdReturnType,
   paymentTime: string,
-  orderStatusData: OrderStatusType,
+  orderStatusList: OrderStatusType[],
 }
 function PaymentSuccessPageData({ ...basisProps }: PaymentSuccessPageDataProps) {
 
   const {resOrderId, ...restProps} = basisProps
   const {data:orderData, isLoading:orderLoading, isError:orderError} = useGetOrderByIdQuery({variables: {uuid: resOrderId}})
-  const {data:orderStatusData, isLoading:orderStatusLoading, isError:orderStatusError} = useGetOrderStatusByIdQuery({variables: {orderId:resOrderId}})
+  const {data:orderStatusList, isLoading:orderStatusLoading, isError:orderStatusError} = useGetOrderStatusByIdQuery({variables: {orderId:resOrderId}})
 
   if (orderLoading || orderStatusLoading) return <Text>주문정보 로딩중</Text>
   if (orderError || orderStatusError) return <Text>주문정보 불러오기 에러</Text>
-  if (orderData === undefined || orderStatusData === undefined) return <Text>주문정보 불러오기 에러2</Text>
+  if (orderData === undefined || orderStatusList === undefined) return <Text>주문정보 불러오기 에러2</Text>
   
-  return <PaymentSuccessPage {...restProps} orderData={orderData} orderStatusData={orderStatusData} />
+  return <PaymentSuccessPage {...restProps} orderData={orderData} orderStatusList={orderStatusList} />
 }
 const {bodyText} = complete_payment_popup_string
 function PaymentSuccessPage({  ...basisProps }: PaymentSuccessPageProps) {
   const route = useRouter()
-  const {paymentTime, orderData, orderStatusData, ...restProps} = basisProps
+  const {paymentTime, orderData, orderStatusList, ...restProps} = basisProps
   const { shippingStatus,created, shipName, shipPhone, shipAddr, shipAddrDetail, shipAddrPost, orderMessage, price, shippingPrice, amount, method } = orderData
-  const {productId, count} = orderStatusData
   const moveToMain = () => {
     route.push({pathname:ROUTES.HOME})
   }
@@ -59,7 +58,9 @@ function PaymentSuccessPage({  ...basisProps }: PaymentSuccessPageProps) {
         px="16px" h="55px" justifyContent="start" alignItems="center">
         <Text textStyle="titleSmall" textColor="black">{formatCreatedTimeToDate(created)}</Text>
       </Flex>
-      <PriceCard px="16px" ispaymentcomplete={true} productid={productId} count={count} status={shippingStatus} />
+      {orderStatusList.map((orderStatus) => 
+      <PriceCard key={orderStatus.id} px="16px" ispaymentcomplete={true} productid={orderStatus.productId} count={orderStatus.count} status={shippingStatus} />
+      )}
       <Box bgColor="gray.100" h="10px" />
       <Flex   // 배송지 정보
         h="55px" alignItems="center" px="16px">

--- a/src/components/common/Card/Commerce.tsx
+++ b/src/components/common/Card/Commerce.tsx
@@ -111,7 +111,7 @@ function CommerceView({...props}:CommerceViewProps){
           <Flex   // 배송비
             mt="15px" justifyContent="space-between"
           >
-            <Text textColor="black" textStyle="text">{`배송비 ${delivery === 0 ? "무료" : delivery}`}</Text>
+            <Text textColor="black" textStyle="text">{`배송비 ${delivery === 0 ? "무료" : delivery+"원"}`}</Text>
             <Text textColor="black" textStyle="titleLarge">{total}{"원"}</Text>
           </Flex>
         </Flex>

--- a/src/components/common/Card/Commerce.tsx
+++ b/src/components/common/Card/Commerce.tsx
@@ -98,7 +98,7 @@ function CommerceView({...props}:CommerceViewProps){
               <Image // 상품 이미지
                 src={photo} w="90px" h="90px" />
               <Flex // 상품 텍스트
-                flexDir="column"
+                flexDir="column" ml="10px"
               >
                 <Text textStyle="title" textColor="black">{name}</Text>
                 <Text textStyle="text" textColor="gray.600">{`${name} | ${capacity}ml`}</Text>

--- a/src/features/orderItem/orderItemSlice.ts
+++ b/src/features/orderItem/orderItemSlice.ts
@@ -12,7 +12,7 @@ export type orderItemType = {
 }
 export interface OrderItemStateType {
   orderItemList: orderItemType[],
-  orderName: string,
+  // orderName: string,
   totalCost: number,
   totalDeliveryCost: number,
 }
@@ -27,7 +27,7 @@ export type addOrderItemType = {
 const noOrderName = "없음"
 const initialState: OrderItemStateType = {
   orderItemList: [],
-  orderName: noOrderName,
+  // orderName: noOrderName,
   totalDeliveryCost: 0, // 총 배달 금액
   totalCost: 0, // 총 금액
 };
@@ -47,20 +47,6 @@ export const orderItemSlice = createSlice({
       })
       if(isNewOrder){
         state.orderItemList.push(action.payload.orderItem)
-        const orginName = state.orderName
-        // 주문이 없던, 새로운 주문이라면 새 주문 아이템 이름만 추가하고 
-        if(orginName === noOrderName){
-          state.orderName = action.payload.orderItem.name
-        }
-        if(orginName !== noOrderName){
-          if(state.orderItemList.length === 2){
-            // 이번에 2개가 되었다면 " 외 1건"만 붙이고
-            state.orderName += `외 ${state.orderItemList.length-1}건`
-          }else{
-            // 아니라면 뒤에 " 외 n건"의 n에 1을 더해줍니다.
-            orginName.replace(`외 ${state.orderItemList.length-2}건`,`외 ${state.orderItemList.length-1}건` )
-          }
-        }
       }
       console.log("아이템 추가 결과:",state.orderItemList)
     },


### PR DESCRIPTION
- 장바구니 상품 사진 여백 및 배송비에 "원" 추가
- 주문 명 slice에서 관리하지 않고 토스 결제할 때마다 만들도록 수정
- 주문 상태 API 로직 변경
- Close #77 #78 